### PR TITLE
adding csv loading functionality for windows

### DIFF
--- a/cardea/data_loader/entityset_loader.py
+++ b/cardea/data_loader/entityset_loader.py
@@ -6,7 +6,6 @@ import sys
 
 from cardea.data_loader import DataLoader, Diamond
 
-platform = sys.platform
 class EntitySetLoader(DataLoader):
     """A class that loads fhir class objects to featuretools entityset."""
 
@@ -89,9 +88,9 @@ class EntitySetLoader(DataLoader):
         csv_files = glob(folder_path + "/*.csv")
         for file_path in csv_files:
             df = pd.read_csv(file_path)
-            if platform == 'win32':
+            if sys.platform.startswith('win32'):
                 file_name = file_path.split("\\")[-1].split(".")[0]
-            elif platorm == 'linux' or 'darwin':
+            else:
                 file_name = file_path.split("/")[-1].split(".")[0]
 
             fhir[file_name] = df

--- a/cardea/data_loader/entityset_loader.py
+++ b/cardea/data_loader/entityset_loader.py
@@ -6,6 +6,7 @@ import sys
 
 from cardea.data_loader import DataLoader, Diamond
 
+
 class EntitySetLoader(DataLoader):
     """A class that loads fhir class objects to featuretools entityset."""
 

--- a/cardea/data_loader/entityset_loader.py
+++ b/cardea/data_loader/entityset_loader.py
@@ -3,6 +3,7 @@ from glob import glob
 
 import featuretools as ft
 import pandas as pd
+
 from cardea.data_loader import DataLoader, Diamond
 
 

--- a/cardea/data_loader/entityset_loader.py
+++ b/cardea/data_loader/entityset_loader.py
@@ -2,10 +2,11 @@ from glob import glob
 
 import featuretools as ft
 import pandas as pd
+import sys
 
 from cardea.data_loader import DataLoader, Diamond
 
-
+platform = sys.platform
 class EntitySetLoader(DataLoader):
     """A class that loads fhir class objects to featuretools entityset."""
 
@@ -88,7 +89,10 @@ class EntitySetLoader(DataLoader):
         csv_files = glob(folder_path + "/*.csv")
         for file_path in csv_files:
             df = pd.read_csv(file_path)
-            file_name = file_path.split("/")[-1].split(".")[0]
+            if platform == 'win32':
+                file_name = file_path.split("\\")[-1].split(".")[0]
+            elif platorm == 'linux' or 'darwin':
+                file_name = file_path.split("/")[-1].split(".")[0]
 
             fhir[file_name] = df
 

--- a/cardea/data_loader/entityset_loader.py
+++ b/cardea/data_loader/entityset_loader.py
@@ -1,9 +1,8 @@
+import sys
 from glob import glob
 
 import featuretools as ft
 import pandas as pd
-import sys
-
 from cardea.data_loader import DataLoader, Diamond
 
 
@@ -115,7 +114,6 @@ class EntitySetLoader(DataLoader):
         entity_set = ft.EntitySet(id="fhir")
 
         for name, df in fhir.items():
-
             object = self.create_object(df, name)
             all_objects.append(object)
 


### PR DESCRIPTION
Added functionality to test for system os to allow csv loading on windows, linux, mac.  When loading under windows there was an error due to incorrect splitting of the file path and naming entity set.  Error stating FHIR standards are not followed.  